### PR TITLE
fix bugs and add docs

### DIFF
--- a/code/cluster/base.py
+++ b/code/cluster/base.py
@@ -111,8 +111,7 @@ class Base(Common):
 		self.log.debug('Casted job in ' + ms + ' ms.')
 
 
-SCRIPT_TEMPLATE = inspect.cleandoc("""
-#!/bin/bash
+SCRIPT_TEMPLATE = inspect.cleandoc("""#!/bin/bash
 
 echo "This is an example script. Hello world!!"
 echo

--- a/code/cluster/lsf.py
+++ b/code/cluster/lsf.py
@@ -52,8 +52,7 @@ class Lsf(Base):
 		)
 
 
-SCRIPT_TEMPLATE = """
-#!/bin/bash
+SCRIPT_TEMPLATE = """#!/bin/bash
 
 #BSUB -P flywheel
 #BSUB -J fw-{{job.fw_id}}

--- a/code/cluster/sge.py
+++ b/code/cluster/sge.py
@@ -44,8 +44,7 @@ class Sge(Base):
 		)
 
 
-SCRIPT_TEMPLATE = """
-#!/usr/bin/env bash
+SCRIPT_TEMPLATE = """#!/usr/bin/env bash
 
 #$ -j y
 #$ -o {{script_log_path}}

--- a/code/cluster/slurm.py
+++ b/code/cluster/slurm.py
@@ -44,8 +44,7 @@ class Slurm(Base):
 		)
 
 
-SCRIPT_TEMPLATE = """
-#!/bin/bash
+SCRIPT_TEMPLATE = """#!/bin/bash
 #SBATCH --job-name=fw-{{job.fw_id}}
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task={{job.cpu}}

--- a/doc/1-choose-an-integration-method.md
+++ b/doc/1-choose-an-integration-method.md
@@ -8,12 +8,41 @@ Check with your admin as to the best option for you.
 
 ## Option 1 - cron
 
-If cron is enabled, this is probably the best choice. The below example would run Cast once a minute:
+If cron is enabled, this is probably the best choice. The below example would run Cast once a minute.
+
+1. Create a new crontab file. Note: you maybe to prepend `sudo` if there are any permission issues.
+
+```
+crontab -e
+```
+
+2. Select a text editor if prompted.
+
+```
+Select an editor.  To change later, run 'select-editor'.
+  1. /bin/nano        <---- easiest
+  2. /usr/bin/vim.basic
+  3. /usr/bin/vim.tiny
+  4. /bin/ed
+
+Choose 1-4 [1]:
+```
+
+3. Enter the task for cron to run (at bottom of the file).  
 
 ```
 */1 * * * * ~/fw-cast/settings/start-cast.sh
 ```
 
+If the script does not run, try using `bash` or `sh` in the command:
+
+```
+*/1 * * * * bash ~/fw-cast/settings/start-cast.sh
+```
+
+4. Save and exit. Save the file with `control + O`, and hit enter when prompted about the file name and location.
+Exit with `control + X`
+   
 For further options, check out [crontab guru](https://crontab.guru/#*/1_*_*_*_*) or your system documentation.
 
 ## Option 2 - tmux

--- a/doc/3-cluster-install.md
+++ b/doc/3-cluster-install.md
@@ -1,4 +1,6 @@
-# Download
+## Set up your environment
+
+### Install python
 
 First, connect to your interactive HPC node.
 
@@ -9,12 +11,31 @@ For example, if your cluster has a `module` system, the command may be something
 module load python/3
 ```
 
+You may also directly be able to install python with the following if you have root privileges:
+
+```
+sudo apt-get update
+sudo apt-get install python3.8
+```
+
 Check with your sysadmin or documentation for more information.<br/>
 Record any commands required, then check the command is healthy and in your path:
 
 ```
 python3 --version
 ```
+
+#### Symlink python to python3
+
+To prevent calling python2 instead of python3, it is recommended that a symlink be created for the command 
+`python` so that any calls default to `python3`. To do so, simply install the package 
+`python-is-python3` with the following:
+
+```
+sudo apt install python-is-python3
+```
+
+### Clone the Cast repo and set up a virtual environment
 
 Add pipenv, which isolates our script dependencies, to your homedir:
 
@@ -35,11 +56,18 @@ git clone <your-github-location> fw-cast
 cd fw-cast
 ```
 
-Prepare your cluster-specific files:
+Setup the pipenv for the fw-cast project:
+```
+cd code
+python -m pipenv install
+cd ../
+```
+
+### Run the `setup` script
+Prepare your cluster-specific files by running the setup script. You may have to 
+prepend `bash` or `sh`.
 
 ```
-pipenv install
-
 ./process/setup.sh
 ```
 
@@ -57,8 +85,9 @@ You need to edit each of these files in turn to configure it for your cluster:
 | Filename         | Purpose               |
 | -----------------| ----------------------|
 | `cast.yml`       | High-level settings   |
-| `credentials.sh` | Sensitive information |
+| `credentials.sh` | Sensitive information and Singularity environment config options |
 | `start-cast.sh`  | Bootstrap script      |
 
 Each file has a variety of comments to guide you through the process.<br/>
-Work with your collaborating Flywheel employee on these settings, particularly the connection credential.
+Work with your collaborating Flywheel employee on these settings, particularly the <br/>
+connection credential (i.e., `SCITRAN_CORE_DRONE_SECRET` in `credentials.sh`).

--- a/examples/settings/start-cast.sh
+++ b/examples/settings/start-cast.sh
@@ -20,4 +20,4 @@ logfile="$PWD/logs/cast.log"
 # Using "timeout" prevents the script hanging when launched automatically.
 # This time limit may need to be adjusted based on the speed of your system.
 cd code
-timeout 5m pipenv run ./cast.py "$@" 2>&1 | tee -a "$logfile"
+timeout 5m python -m pipenv run ./cast.py "$@" 2>&1 | tee -a "$logfile"


### PR DESCRIPTION
# bug
- remove blank from SCRIPT_TEMPLATE for shebang
```
sbatch: error: This does not look like a batch script.  The first
sbatch: error: line must start with #! followed by the path to an interpreter.
sbatch: error: For instance: #!/bin/sh
11-22 16:22:30 CRIT Error executing command. Exec error follows:
11-22 16:22:30 CRIT Command '['sbatch', '/home/jiavila/fw-cast/logs/generated/job-618ecb554227e0a0069ef189.sh']' returned non-zero exit status 1.
11-22 16:22:30 CRIT Exiting.
```
- fix calls to `pipenv` by adding `python -m` to `start-cast

# enh:
- add more cron doc
- add more pipenv doc