### PR TITLE
Gear 2415 support slurm cpu ram

### DIFF
--- a/code/util/defn.py
+++ b/code/util/defn.py
@@ -9,6 +9,8 @@ class ConfigFileCast(BaseModel):
 
 	cluster:   str
 	dry_run:   bool
+	slurm_ram:	str
+	slurm_cpu:	str
 
 	admin_contact_email:  str
 	group_whitelist:      bool
@@ -27,7 +29,6 @@ class ConfigFileCast(BaseModel):
 	script_executable:    Optional[bool]
 
 	use_hold_engine: bool
-
 
 class ConfigFile(BaseModel):
 	"""

--- a/examples/settings/cast.yml
+++ b/examples/settings/cast.yml
@@ -2,17 +2,19 @@ cast:
 
   # Cluster type.
   # For a list of valid values, see cluster/__init__.py.
-  cluster: 'base'
+  cluster: 'slurm'
 
-  # When set, scripts are still generated, but no HPC commands are ran.
+  # When set, scripts are still generated, but no HPC commands are run.
   # Useful for testing.
-  dry_run: true
+  dry_run: false
 
   # Contact email provided to users who run into errors.
   admin_contact_email: '<Your-Email-Here>'
 
-  # When set, jobs are only allowed from users added to a group whitelist.
-  group_whitelist: true
+  # When set, jobs are only allowed from users added to a group whitelist.  If `true`,
+  # Cast will look for users added to a group called "hpc-whitelist" in your Flywheel
+  # instance. It is recommended that the group label and ID be the same (i.e., "hpc-whitelist")
+  group_whitelist: false
 
   # When set, jobs with the tag "hpc" are cast.
   cast_on_tag: true
@@ -25,12 +27,17 @@ cast:
 
   # When enabled, templating properties will be dumped to the log.
   # Useful for debugging a script or command template.
-  show_script_template_values: false
-  show_script_template_result: false
+  show_script_template_values: true
+  show_script_template_result: true
   show_commnd_template_result: true
 
   # Internal Flywheel setting. Leave this at default unless instructed.
   use_hold_engine: true
+
+  # Settings for slurm cluster ram and cpu. Uncomment if you wish to set these for all
+  # your slurm jobs.
+  # slurm_cpu: '4'
+  # slurm_ram: '12G'
 
   #
   # Depending on your cluster implementation,

--- a/examples/settings/credentials.sh
+++ b/examples/settings/credentials.sh
@@ -39,4 +39,13 @@ export PATH=$PATH:/usr/local/bin/
 # OCI/docker layers used to create them". The default is $HOME/.singularity/cache
 # export SINGULARITY_CACHEDIR="path/to/singularity/cache"
 
+# Use SINGULARITY_BIND if you would like to mount an additional directory to the
+# singularity image/SIF file. This can be useful if you would like to use a writable
+# directory for creating temporary files instead of generating them in the default /tmp
+# directory.
+# The argument for this option is a comma-delimited string of bind path specifications in the format src[:dest[:opts]],
+# where src and dest are paths outside and inside the container, respectively. If dest is not given, it is set equal to src. Mount options
+# (opts) may be specified as ro (read-only) or rw (read/writ, which is the default). A comma-delimited string of bind path specifications can be used.
+# export SINGULARITY_BIND="/scratch/oa22/fmripreptempdir"
+
 # Do NOT put other engine settings in this file.

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,8 @@ The HPC Client is a self-service solution that allows Flywheel jobs and gears to
 
 ## HPC types
 
-The client, also called Cast, supports several queue mechanisms out of the box:
+The client, also called Cast, can support several queue mechanisms out of the box. Flywheel, however, currently only
+provides support for Slurm. If you require assistance with other schedulers, contact Flywheel.
 
 | Common name              | Code name |
 | -------------------------| ----------|
@@ -27,6 +28,7 @@ Otherwise, some light python development will be required.
 
 1. Before using Cast, you need to decide how it will run on your cluster.<br/>
 [Choose an integration method](doc/1-choose-an-integration-method.md) and keep it in mind for later.
+   This sets how frequent Cast with look for, pull, and queue hpc jobs to your HPC from your Flywheel site.
 
 2. It is strongly recommended that you [make a private github repo](doc/2-tracking-changes-privately.md) to track your changes.<br/>
 This will make Cast much easier to manage.
@@ -40,10 +42,17 @@ singularity, it is recommended that you read--at a minimum--SingularityCE's [int
 
 5. If your queue type is not in the above table, or is sufficiently different, review the guide for [adding a queue type](doc/4-development-guide.md).
 
-6. Collaborate with Flywheel staff to [install an Engine binaries](doc/Flywheel%20HPC%20Client%20-%20engine%20configuration.pdf) 
-   and run your first HPC job tests.
+6. Collaborate with Flywheel staff to [install an Engine binaries](doc/Flywheel%20HPC%20Client%20-%20engine%20configuration.pdf).
+   They will also configure the hold engine on your Flywheel site
+   to ensure that other engines do not pick up gear jobs that are tagged with "hpc".
 
 7. Complete the integration method you chose in step one.<br/>
-Confirm Cast is running regularly by monitoring `logs/cast.log` and the Flywheel user interface.
+   Confirm Cast is running regularly by monitoring `logs/cast.log` and the Flywheel user interface.
+   
+8. Test and run your first HPC job tests in collaboration with Flywheel. It is recommended
+   that you test with MRIQC (non-BIDS version), a gear that's available from Flywheel's [Gear Exchange](https://flywheel.io/gear-exchange/).
+   Note: as of 11 May 2022, Flywheel will have to change the rootfs-url (location of where the Docker image resides) for
+   any gears installed from the Gear Exchange. For more about how Cast uses a rootfs-url, see Background/Motivation
+   of [this article](https://docs.flywheel.io/hc/en-us/articles/4607520806547-Using-pre-built-singularity-images-sif-with-your-HPC).
 
 8. Enjoy!


### PR DESCRIPTION

- ENH

- [add ability to set slurm ram and cpu in settings/cast.yml](https://github.com/flywheel-io/hpc-client/commit/9aa9b40cdac1b57908b1a38bb0c1d146f9f1d7d2)

DOCS
- Update docs: default settings for cast.yml, option for SINGULARITY_BIND, additional steps needed to complete HPC integration
